### PR TITLE
Fix titles that are set to use Basilisk-Portable.exe

### DIFF
--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -15,6 +15,15 @@
 // Project Includes
 #include "command.h"
 
+/* TODO: While it might be problematic to implement, it would be much cleaner in the end
+ * and go a long way towards making the Linux port easier to achieve if the task types
+ * had their handling moved to be internal by an invokeable method like inheritance is
+ * usually employed, instead of checking for and casting to the type within Driver. Some
+ * of the concerns about how to interact with driver contained objects/functions while
+ * doing this may be able to be aliveated by making the task classes inherit QObject
+ * and then using signals/slots
+ */
+
 //===============================================================================================================
 // DRIVER
 //===============================================================================================================
@@ -200,6 +209,15 @@ void Driver::processExecTask(const std::shared_ptr<Core::ExecTask> task)
 {
     // Emit complete signal on return unless dismissed
     QScopeGuard autoFinishEmitter([this](){ emit __currentTaskFinished(); });
+
+    // TODO: Remove this as soon as FP fixes this shit
+    //Check for Basilisk exception
+    if(task->filename == "Basilisk-Portable.exe")
+    {
+        mCore->logEvent(NAME, LOG_EVENT_BaSILISK_EXCEPTION);
+        task->filename = "FPNavigator.exe";
+        task->path.replace("Basilisk-Portable", "fpnavigator-portable");
+    }
 
     // Ensure executable exists
     QFileInfo executableInfo(task->path + "/" + task->filename);

--- a/src/driver.h
+++ b/src/driver.h
@@ -85,6 +85,7 @@ private:
     static inline const QString LOG_EVENT_STOPPING_WAIT_PROCESS = "Stopping current wait on execution process...";
     static inline const QString LOG_EVENT_STOPPING_DOWNLOADS = "Stopping current download(s)...";
     static inline const QString LOG_EVENT_STOPPING_MOUNT = "Stopping current mount(s)...";
+    static inline const QString LOG_EVENT_BaSILISK_EXCEPTION = "ExecTask calls for Basilisk-Portable. Swapping for FPNavigator";
 
 
     // Meta


### PR DESCRIPTION
The regular launcher secretly swaps this application to FPNavigator.