### PR TITLE
Fix crash when multiple entries share the same title by creating the title disambiguation dialog in the correct thread

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -42,6 +42,7 @@ Controller::Controller(QObject* parent) :
     // Connect driver - Response Requested  (BlockingQueuedConnection since response must be waited for)
     connect(driver, &Driver::blockingErrorOccured, &mStatusRelay, &StatusRelay::blockingErrorHandler, Qt::BlockingQueuedConnection);
     connect(driver, &Driver::saveFileRequested, &mStatusRelay, &StatusRelay::saveFileRequestHandler, Qt::BlockingQueuedConnection);
+    connect(driver, &Driver::itemSelectionRequested, &mStatusRelay, &StatusRelay::itemSelectionRequestHandler, Qt::BlockingQueuedConnection);
 
     // Connect quit handler
     connect(&mStatusRelay, &StatusRelay::quitRequested, this, &Controller::quitRequestHandler);

--- a/src/frontend/statusrelay.cpp
+++ b/src/frontend/statusrelay.cpp
@@ -92,6 +92,16 @@ void StatusRelay::saveFileRequestHandler(QSharedPointer<QString> file, Core::Sav
                                          request.filter, request.selectedFilter, request.options);
 }
 
+void StatusRelay::itemSelectionRequestHandler(QSharedPointer<QString> item, const Core::ItemSelectionRequest& request)
+{
+    /* TODO: Either implement a custom dialog that doesn't have a cancel button, or handle use of the cancel button.
+     * In order to avoid needing a second return argument for the "ok" value of the dialog, simply set 'item' to
+     * a null string if ok==false (cancel was pressed), and check for that in the caller. This would be similar
+     * to how cancellation is handled for save file requests.
+     */
+    *item = QInputDialog::getItem(nullptr, request.caption, request.label, request.items, 0, false);
+}
+
 void StatusRelay::longTaskProgressHandler(quint64 progress)
 {
     mLongTaskProgressDialog.setValue(progress);

--- a/src/frontend/statusrelay.h
+++ b/src/frontend/statusrelay.h
@@ -7,6 +7,7 @@
 #include <QSystemTrayIcon>
 #include <QMenu>
 #include <QAuthenticator>
+#include <QInputDialog>
 
 // Project Includes
 #include "kernel/core.h"
@@ -45,6 +46,7 @@ public slots:
     void blockingErrorHandler(QSharedPointer<int> response, Core::BlockingError blockingError);
     void messageHandler(const QString& message);
     void saveFileRequestHandler(QSharedPointer<QString> file, Core::SaveFileRequest request);
+    void itemSelectionRequestHandler(QSharedPointer<QString> item, const Core::ItemSelectionRequest& request);
 
     // Long Job
     void longTaskProgressHandler(quint64 progress);

--- a/src/kernel/core.cpp
+++ b/src/kernel/core.cpp
@@ -3,7 +3,6 @@
 
 // Qt Includes
 #include <QApplication>
-#include <QInputDialog>
 
 // Qx Includes
 #include <qx/utility/qx-helpers.h>
@@ -310,7 +309,12 @@ ErrorCode Core::getGameIDFromTitle(QUuid& returnBuffer, QString title)
         }
 
         // Get user choice
-        QString userChoice = QInputDialog::getItem(nullptr, MULTI_TITLE_SEL_CAP, MULTI_TITLE_SEL_LABEL, idChoices);
+        Core::ItemSelectionRequest isr{
+            .caption = MULTI_TITLE_SEL_CAP,
+            .label = MULTI_TITLE_SEL_LABEL,
+            .items = idChoices
+        };
+        QString userChoice = requestItemSelection(isr);
 
         // Set return buffer
         returnBuffer = idMap.value(userChoice);
@@ -731,6 +735,18 @@ QString Core::requestSaveFilePath(const SaveFileRequest& request)
 
     // Return response
     return *file;
+}
+
+QString Core::requestItemSelection(const ItemSelectionRequest& request)
+{
+    // Response holder
+    QSharedPointer<QString> item = QSharedPointer<QString>::create();
+
+    // Emit and get response
+    emit itemSelectionRequested(item, request);
+
+    // Return response
+    return *item;
 }
 
 Fp::Install& Core::fpInstall() { return *mFlashpointInstall; }

--- a/src/kernel/core.h
+++ b/src/kernel/core.h
@@ -55,6 +55,13 @@ public:
         QFileDialog::Options options;
     };
 
+    struct ItemSelectionRequest
+    {
+        QString caption;
+        QString label;
+        QStringList items;
+    };
+
 //-Class Variables------------------------------------------------------------------------------------------------------
 public:
     // Status
@@ -210,7 +217,8 @@ public:
     void postError(QString src, Qx::GenericError error, bool log = true);
     int postBlockingError(QString src, Qx::GenericError error, bool log = true, QMessageBox::StandardButtons bs = QMessageBox::Ok, QMessageBox::StandardButton def = QMessageBox::NoButton);
     void postMessage(QString msg);
-    QString requestSaveFilePath(const SaveFileRequest& req);
+    QString requestSaveFilePath(const SaveFileRequest& request);
+    QString requestItemSelection(const ItemSelectionRequest& request);
 
     // Member access
     Fp::Install& fpInstall();
@@ -232,6 +240,7 @@ signals:
     void errorOccured(const Core::Error& error);
     void blockingErrorOccured(QSharedPointer<int> response, const Core::BlockingError& blockingError);
     void saveFileRequested(QSharedPointer<QString> file, const Core::SaveFileRequest& request);
+    void itemSelectionRequested(QSharedPointer<QString> item, const Core::ItemSelectionRequest& request);
     void message(const QString& message);
 };
 

--- a/src/kernel/driver.cpp
+++ b/src/kernel/driver.cpp
@@ -36,6 +36,7 @@ void Driver::init()
     connect(mCore, &Core::blockingErrorOccured, this, &Driver::blockingErrorOccured);
     connect(mCore, &Core::message, this, &Driver::message);
     connect(mCore, &Core::saveFileRequested, this, &Driver::saveFileRequested);
+    connect(mCore, &Core::itemSelectionRequested, this, &Driver::itemSelectionRequested);
 
     //-Setup deferred process manager------
     /* NOTE: It looks like the manager should just be a stack member of TExec that is constructed

--- a/src/kernel/driver.h
+++ b/src/kernel/driver.h
@@ -112,6 +112,7 @@ signals:
     void blockingErrorOccured(QSharedPointer<int> response, const Core::BlockingError& blockingError);
     void message(const QString& message);
     void saveFileRequested(QSharedPointer<QString> file, const Core::SaveFileRequest& request);
+    void itemSelectionRequested(QSharedPointer<QString> item, const Core::ItemSelectionRequest& request);
 
     // Long task
     void longTaskProgressChanged(quint64 progress);


### PR DESCRIPTION
Since this dialog is almost never used/seen, when CLIFp was reworked to be multithreaded the creation of the dialog was inadvertently left within Core and therefore was spawned in the wrong thread, leading to a crash in the rare case that a name was specified that was shared by multiple titles.