### PR TITLE
Don't assume docker is used on Linux; Adds minimal support for non-standard configurations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ fetch_qx("f1b1eb0962734f9b6a7bb55fc6a908b3a13862fe")
 
 # Fetch libfp (build and import from source)
 include(OB/Fetchlibfp)
-fetch_libfp("v0.1.4")
+fetch_libfp("1e1ad41530ad4a71f6292b39cfbaf6dd543af9b7")
 
 # Fetch QI-QMP (build and import from source)
 include(OB/FetchQI-QMP)


### PR DESCRIPTION
Previously the wait for  the docker image to come alive on Linux was performed unconditionally, regardless of whether or not services.json dictated that docker was being used. This change alters CLIFp such that it won't queue up the Docker wait task if Docker isn't actually set as the server.

This allows for experimenting with modified Flashpoint configurations while still using CLIFp.