### PR TITLE
Fix handling of several niche aspects of Linux specific TExec implementation

### DIFF
--- a/src/task/t-exec.h
+++ b/src/task/t-exec.h
@@ -23,13 +23,21 @@ private:
     // Meta
     static inline const QString NAME = QStringLiteral("TExec");
 
-    // Logging
-    static inline const QString LOG_EVENT_CD = "Changed current directory to: %1";
-    static inline const QString LOG_EVENT_INIT_PROCESS = "Starting '%1' (%2)...";
-    static inline const QString LOG_EVENT_START_PROCESS = "Started %1 process '%2': %3";
+    // Logging - Process Prep
+    static inline const QString LOG_EVENT_PREPARING_PROCESS = "Preparing %1 process '%2' (%3)...";
+    static inline const QString LOG_EVENT_FINAL_EXECUTABLE = "Final Executable: %1";
+    static inline const QString LOG_EVENT_FINAL_PARAMETERS = "Final Parameters: %1";
+
+    // Logging - Process Attribute Modification
     static inline const QString LOG_EVENT_ARGS_ESCAPED = "CMD arguments escaped from [[%1]] to [[%2]]";
     static inline const QString LOG_EVENT_FORCED_BASH = "Forced use of 'sh' from Windows 'bat'";
     static inline const QString LOG_EVENT_FORCED_WIN = "Forced use of WINE from Windows 'exe'";
+
+
+    // Logging - Process Management
+    static inline const QString LOG_EVENT_CD = "Changed current directory to: %1";
+    static inline const QString LOG_EVENT_STARTING = "Starting '%1' (%2)";
+    static inline const QString LOG_EVENT_STARTED_PROCESS = "Started '%1'";
     static inline const QString LOG_EVENT_STOPPING_BLOCKING_PROCESS = "Stopping blocking process '%1'...";
 
     // Errors
@@ -80,7 +88,7 @@ private:
     bool cleanStartProcess(QProcess* process);
 
     // Logging
-    void logProcessStart(const QProcess* process, ProcessType type);
+    void logPreparedProcess(const QProcess* process);
 
 public:
     // Member access

--- a/src/task/t-exec_linux.cpp
+++ b/src/task/t-exec_linux.cpp
@@ -7,9 +7,6 @@
 // Qx Includes
 #include <qx/core/qx-algorithm.h>
 
-// Project Includes
-#include "utility.h"
-
 namespace // Unit helper functions
 {
 
@@ -157,11 +154,10 @@ QProcess* TExec::prepareProcess(const QFileInfo& execInfo)
     }
 }
 
-void TExec::logProcessStart(const QProcess* process, ProcessType type)
+void TExec::logPreparedProcess(const QProcess* process)
 {
-    QString eventStr = process->program();
-    if(!process->arguments().isEmpty())
-        eventStr += " {\"" + process->arguments().join(R"(", ")") + "\"}";
-
-    emit eventOccurred(NAME, LOG_EVENT_START_PROCESS.arg(ENUM_NAME(type), mIdentifier, eventStr));
+    emit eventOccurred(NAME, LOG_EVENT_FINAL_EXECUTABLE.arg(process->program()));
+    emit eventOccurred(NAME, LOG_EVENT_FINAL_PARAMETERS.arg(!process->arguments().isEmpty() ?
+                                                            "{\"" + process->arguments().join(R"(", ")") + "\"}" :
+                                                            ""));
 }

--- a/src/task/t-exec_linux.cpp
+++ b/src/task/t-exec_linux.cpp
@@ -80,7 +80,10 @@ QString TExec::resolveExecutablePath()
     // as a last resort
     QFileInfo execInfo(mExecutable);
     if(execInfo.suffix() == SHELL_EXT_WIN)
+    {
         execInfo.setFile(mExecutable.chopped(sizeof(SHELL_EXT_WIN)) + SHELL_EXT_LINUX);
+        emit eventOccurred(NAME, LOG_EVENT_FORCED_BASH);
+    }
 
     // Mostly standard processing
     if(execInfo.isAbsolute())
@@ -128,7 +131,7 @@ QProcess* TExec::prepareProcess(const QFileInfo& execInfo)
 {
     if(execInfo.suffix() == EXECUTABLE_EXT_WIN)
     {
-        emit eventOccurred(NAME, LOG_EVENT_FORCED_BASH);
+        emit eventOccurred(NAME, LOG_EVENT_FORCED_WIN);
 
         // Resolve passed parameters
         QString exeParam = std::holds_alternative<QStringList>(mParameters) ?

--- a/src/task/t-exec_linux.cpp
+++ b/src/task/t-exec_linux.cpp
@@ -10,7 +10,7 @@
 namespace // Unit helper functions
 {
 
-QProcess* setupExeProcess(const QString& exePath, const QString& exeArgs)
+QProcess* setupExeProcess(const QString& exePath, const QStringList& exeArgs)
 {
     QProcess* process = new QProcess();
 
@@ -18,13 +18,15 @@ QProcess* setupExeProcess(const QString& exePath, const QString& exeArgs)
     process->setProgram("wine");
 
     // Set arguments
-    process->setArguments({
+    QStringList fullArgs{
         "start",
         "/wait",
-        "/unix",
-        exePath,
-        exeArgs
-    });
+        "/unix"
+    };
+    fullArgs.append(exePath);
+    fullArgs.append(exeArgs);
+
+    process->setArguments(fullArgs);
 
     return process;
 }
@@ -131,9 +133,9 @@ QProcess* TExec::prepareProcess(const QFileInfo& execInfo)
         emit eventOccurred(NAME, LOG_EVENT_FORCED_WIN);
 
         // Resolve passed parameters
-        QString exeParam = std::holds_alternative<QStringList>(mParameters) ?
-                           collapseArguments(std::get<QStringList>(mParameters)) :
-                           std::get<QString>(mParameters);
+        QStringList exeParam = std::holds_alternative<QString>(mParameters) ?
+                               QProcess::splitCommand(std::get<QString>(mParameters)) :
+                               std::get<QStringList>(mParameters);
 
         return setupExeProcess(execInfo.filePath(), exeParam);
     }

--- a/src/task/t-exec_win.cpp
+++ b/src/task/t-exec_win.cpp
@@ -113,11 +113,10 @@ QProcess* TExec::prepareProcess(const QFileInfo& execInfo)
         return setupNativeProcess(execInfo.filePath(), mParameters);
 }
 
-void TExec::logProcessStart(const QProcess* process, ProcessType type)
+void TExec::logPreparedProcess(const QProcess* process)
 {
-    QString eventStr = process->program();
-    if(!process->nativeArguments().isEmpty())
-        eventStr += " " + process->nativeArguments();
-
-    emit eventOccurred(NAME, LOG_EVENT_START_PROCESS.arg(ENUM_NAME(type), mIdentifier, eventStr));
+    emit eventOccurred(NAME, LOG_EVENT_FINAL_EXECUTABLE.arg(process->program()));
+    emit eventOccurred(NAME, LOG_EVENT_FINAL_PARAMETERS.arg(!process->nativeArguments().isEmpty() ?
+                                                            process->nativeArguments() :
+                                                            ""));
 }


### PR DESCRIPTION
- Fix inaccurate logging when using the exe -> WINE last resort fallback
- Fix missing logging when using the bat -> sh last resort fallback
- Fix argument quoting for the exe -> WINE last resort fallback