### PR TITLE
Fix empty platform data when enqueuing add. app via CPlay

### DIFF
--- a/src/command/c-play.cpp
+++ b/src/command/c-play.cpp
@@ -175,8 +175,11 @@ ErrorCode CPlay::enqueueAutomaticTasks(bool& wasStandalone, QUuid targetId)
             return ErrorCode::SQL_ERROR;
         }
 
+        // Advance result to only record
+        parentResult.result.next();
+
         // Determine platform (don't bother building entire game object since only one value is needed)
-        QString platform = parentResult.size != 1 ? "" : parentResult.result.value(Fp::Db::Table_Game::COL_PLATFORM).toString();
+        QString platform = parentResult.result.value(Fp::Db::Table_Game::COL_PLATFORM).toString();
 
         // Enqueue
         enqueueError = enqueueAdditionalApp(addApp, platform, Task::Stage::Primary);


### PR DESCRIPTION
The database query result wasn't being advanced to the first record and so when the platform of the additional app's parent was checked an empty string was always received.