### PR TITLE
Prevent phantom progress bar when long task fails immediately

### DIFF
--- a/app/src/frontend/statusrelay.cpp
+++ b/app/src/frontend/statusrelay.cpp
@@ -133,6 +133,9 @@ void StatusRelay::longTaskStartedHandler(QString task)
 
 void StatusRelay::longTaskFinishedHandler()
 {
-    if(mLongTaskProgressDialog.isVisible()) // Is already closed if canceled
-        mLongTaskProgressDialog.reset();
+    /* Always reset the dialog regardless of whether it is visible or not as it may not be currently visible,
+     * but queued to be visible on the next event loop iteration and therefore still needs to be hidden
+     * immediately after.
+     */
+     mLongTaskProgressDialog.reset();
 }


### PR DESCRIPTION
Ensures that the long task progress bar is still hidden even if a long task fails within the same event loop iteration that it is started in.