### PR TITLE
Actions: Simply build matricies

### DIFF
--- a/.github/workflows/build-clifp-linux.yml
+++ b/.github/workflows/build-clifp-linux.yml
@@ -18,35 +18,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        compiler: [clang]
-        lib_linkage: [shared, static]
-        include:
-          - os: ubuntu-20.04
-            compiler: clang
-            c_comp: clang-12
-            cxx_comp: clang++-12
-            qt_comp: clang12            
-          - os: ubuntu-22.04
-            compiler: gcc
-            c_comp: gcc-12
-            cxx_comp: g++-12
-            qt_comp: clang14
-            lib_linkage: shared
-          - os: ubuntu-22.04
-            compiler: gcc
-            c_comp: gcc-12
-            cxx_comp: g++-12
-            qt_comp: clang14
-            lib_linkage: static
-          - os: ubuntu-22.04
-            compiler: clang
-            c_comp: clang-14
-            cxx_comp: clang++-14
-            qt_comp: clang14
-          - lib_linkage: shared
-            cmake_bsl: ON
-          - lib_linkage: static
-            cmake_bsl: OFF
+        compiler: [{c: gcc-12, cxx: g++-12, qt: clang14}, {c: clang-12, cxx: clang++-12, qt: clang12}, {c: clang-14, cxx: clang++-14, qt: clang14}]
+        linkage: [{type: shared, cmake_bsl: ON}, {type: static, cmake_bsl: OFF}]
+        exclude:
+            - os: ubuntu-20.04
+              compiler: {c: gcc-12, cxx: g++-12, qt: clang14}
+            - os: ubuntu-20.04
+              compiler: {c: clang-14, cxx: clang++-14, qt: clang14}
+            - os: ubuntu-22.04
+              compiler: {c: clang-12, cxx: clang++-12, qt: clang12}
     runs-on: ${{ matrix.os }}
     env:
       cmake_gen: Ninja Multi-Config
@@ -62,8 +42,8 @@ jobs:
       with:
         version: 6.6.0
         os: linux
-        compiler: ${{ matrix.qt_comp }}
-        linkage: ${{ matrix.lib_linkage }}
+        compiler: ${{ matrix.compiler.qt }}
+        linkage: ${{ matrix.linkage.type }}
         path: ${{ env.qt_install_dir }}
         credentials: ${{ secrets.qt_ffynnon_cred }}
     - name: Update package index
@@ -92,7 +72,7 @@ jobs:
       working-directory: ${{ env.clifp_src_dir }}
       run: |
         echo Configuring CMake...
-        "$qt_cmake" -G "$cmake_gen" -S "$clifp_src_dir" -B "$clifp_build_dir" -D BUILD_SHARED_LIBS="${{ matrix.cmake_bsl }}" -D CMAKE_CXX_COMPILER="${{ matrix.cxx_comp }}" -D CMAKE_C_COMPILER="${{ matrix.c_comp }}"
+        "$qt_cmake" -G "$cmake_gen" -S "$clifp_src_dir" -B "$clifp_build_dir" -D BUILD_SHARED_LIBS="${{ matrix.linkage.cmake_bsl }}" -D CMAKE_CXX_COMPILER="${{ matrix.compiler.cxx }}" -D CMAKE_C_COMPILER="${{ matrix.compiler.c }}"
         echo Changing to build directory...
         cd "$clifp_build_dir"
         echo Building CLIFp Release...
@@ -105,7 +85,7 @@ jobs:
     - name: Get CLIFp artifact name
       run: |
         cpack_name=$(find "${{ env.clifp_package_path }}" -type f -name "*.zip")
-        artifact_name="$(basename "$cpack_name" .zip) [${{ matrix.cxx_comp }}]"
+        artifact_name="$(basename "$cpack_name" .zip) [${{ matrix.compiler.cxx }}]"
         echo "current_artifact_name=$artifact_name" >> $GITHUB_ENV
     - name: Upload CLIFp build artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build-clifp-windows.yml
+++ b/.github/workflows/build-clifp-windows.yml
@@ -17,12 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        lib_linkage: [shared, static]
-        include:
-          - lib_linkage: shared
-            cmake_bsl: ON
-          - lib_linkage: static
-            cmake_bsl: OFF
+        linkage: [{type: shared, cmake_bsl: ON}, {type: static, cmake_bsl: OFF}]
     runs-on: windows-latest
     env:
       vs_dir: C:/Program Files/Microsoft Visual Studio/2022/Enterprise
@@ -40,7 +35,7 @@ jobs:
         version: 6.6.0
         os: windows
         compiler: msvc2022
-        linkage: ${{ matrix.lib_linkage }}
+        linkage: ${{ matrix.linkage.type }}
         path: ${{ env.qt_install_dir }}
         credentials: ${{ secrets.qt_ffynnon_cred }}
     - name: Checkout CLIFp
@@ -55,7 +50,7 @@ jobs:
         echo "Setup C++ Build Environment..."
         CALL "${{ env.vs_dir }}\Common7\Tools\VsDevCmd.bat" -arch=amd64
         echo "Configure CMake using Qt wrapper..."
-        CALL "${{ env.qt_cmake }}" -G "${{ env.cmake_gen }}" -S "${{ env.clifp_src_dir}}" -B "${{ env.clifp_build_dir }}" -D BUILD_SHARED_LIBS=${{ matrix.cmake_bsl }}
+        CALL "${{ env.qt_cmake }}" -G "${{ env.cmake_gen }}" -S "${{ env.clifp_src_dir}}" -B "${{ env.clifp_build_dir }}" -D BUILD_SHARED_LIBS=${{ matrix.linkage.cmake_bsl }}
         echo "Changing to build directory..."
         cd "%clifp_build_dir%"
         echo "Building CLIFp release..."


### PR DESCRIPTION
Utilize maps for some matrix entries (undocummented feature) to greatly simplify he matricies for builds. Still requires some cruft with the use of "exclude", but overall the setup is much clearer, readable, and less prone to error.