### PR TITLE
Add general 'fullscreen' switch to CPlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Notes:
 Options:
 
 - [Title Command](#title-commands) options
+- **-f | --fullscreen:** Forces the title to run in full screen if the underlying executable supports it.
 - **--ruffle:** Forces the use of Ruffle for applicable Flash games. Takes precedence over **--flash**.
 - **--flash:** Forces the use of the standard app (usually Flash Player) for applicable Flash games.
 

--- a/lib/backend/src/command/c-run.cpp
+++ b/lib/backend/src/command/c-run.cpp
@@ -66,7 +66,7 @@ Qx::Error CRun::perform()
 
 #ifdef _WIN32
     // Add wait task if required
-    if(Qx::Error ee = mCore.conditionallyEnqueueBideTask(inputInfo); ee.isValid())
+    if(Qx::Error ee = mCore.conditionallyEnqueueBideTask(runTask); ee.isValid())
         return ee;
 #endif
 

--- a/lib/backend/src/kernel/core.cpp
+++ b/lib/backend/src/kernel/core.cpp
@@ -631,13 +631,14 @@ void Core::enqueueShutdownTasks()
 }
 
 #ifdef _WIN32
-Qx::Error Core::conditionallyEnqueueBideTask(QFileInfo precedingAppInfo)
+Qx::Error Core::conditionallyEnqueueBideTask(const TExec* precedingTask)
 {
     const Fp::Toolkit* tk = mFlashpointInstall->toolkit();
 
     // Add wait for apps that involve secure player
+    QFileInfo preeedingInfo(precedingTask->executable());
     bool involvesSecurePlayer;
-    Qx::Error securePlayerCheckError = tk->appInvolvesSecurePlayer(involvesSecurePlayer, precedingAppInfo);
+    Qx::Error securePlayerCheckError = tk->appInvolvesSecurePlayer(involvesSecurePlayer, preeedingInfo);
     if(securePlayerCheckError.isValid())
     {
         postDirective<DError>(securePlayerCheckError);

--- a/lib/backend/src/kernel/core.h
+++ b/lib/backend/src/kernel/core.h
@@ -79,6 +79,8 @@ private:
     QString deriveSecondary() const override;
 };
 
+class TExec;
+
 class Core : public QObject, public Directorate
 {
     Q_OBJECT;
@@ -252,7 +254,7 @@ public:
     CoreError enqueueStartupTasks(const QString& serverOverride = {});
     void enqueueShutdownTasks();
 #ifdef _WIN32
-    Qx::Error conditionallyEnqueueBideTask(QFileInfo precedingAppInfo);
+    Qx::Error conditionallyEnqueueBideTask(const TExec* precedingTask);
 #endif
     Qx::Error enqueueDataPackTasks(const Fp::GameData& gameData);
     void enqueueSingleTask(Task* task);


### PR DESCRIPTION
Adds a full screen parameter to the title's underlying executable automatically if available and known.

Only Ruffle is currently supported.